### PR TITLE
chore: Bump version to v2.0.0

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-test-state-machine-client"
-version = "1.1.1"
+version = "2.0.0"
 edition = "2021"
 authors = ["The Internet Computer Project Developers"]
 description = "Rust library to interact with the ic-test-state-machine."


### PR DESCRIPTION
In preparation for the next release, major version increase due to breaking changes.