### PR TITLE
Add support to set time to a specific value

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-test-state-machine-client"
-version = "2.0.0"
+version = "2.1.0"
 edition = "2021"
 authors = ["The Internet Computer Project Developers"]
 description = "Rust library to interact with the ic-test-state-machine."

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -18,6 +18,7 @@ use std::time::{Duration, SystemTime};
 pub enum Request {
     RootKey,
     Time,
+    SetTime(SystemTime),
     AdvanceTime(Duration),
     CanisterUpdateCall(CanisterCall),
     CanisterQueryCall(CanisterCall),
@@ -282,6 +283,10 @@ impl StateMachine {
 
     pub fn time(&self) -> SystemTime {
         self.call_state_machine(Request::Time)
+    }
+
+    pub fn set_time(&self, time: SystemTime) {
+        self.call_state_machine(Request::SetTime(time))
     }
 
     pub fn advance_time(&self, duration: Duration) {


### PR DESCRIPTION
This adds support to set the time to a specific value to the client library.

Note: This is not yet supported by the state machine binary. But the client library needs to have support first, because the binary uses the `Request` types from it.