### PR TITLE
build: bump ic_cdk to v0.9

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -16,6 +16,6 @@ repository = "https://github.com/dfinity/test-state-machine-client"
 [dependencies]
 candid = "0.8"
 ciborium = "0.2"
-ic-cdk = "0.8"
+ic-cdk = "0.9"
 serde = "1"
 serde_bytes = "0.11"


### PR DESCRIPTION
This is required to use this library with the latest ic_cdk v0.9