### PR TITLE
upgrade candid 0.9 and drop ic-cdk dependency

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-test-state-machine-client"
-version = "2.2.1"
+version = "3.0.0"
 edition = "2021"
 authors = ["The Internet Computer Project Developers"]
 description = "Rust library to interact with the ic-test-state-machine."

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -14,8 +14,7 @@ repository = "https://github.com/dfinity/test-state-machine-client"
 
 
 [dependencies]
-candid = "0.8"
+candid = "0.9"
 ciborium = "0.2"
-ic-cdk = "0.8"
 serde = "1"
 serde_bytes = "0.11"

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -1,10 +1,9 @@
+use crate::management_canister::{
+    CanisterId, CanisterIdRecord, CanisterInstallMode, CreateCanisterArgument, InstallCodeArgument,
+};
 use candid::utils::{ArgumentDecoder, ArgumentEncoder};
 use candid::{decode_args, encode_args, Principal};
 use ciborium::de::from_reader;
-use ic_cdk::api::management_canister::main::{
-    CanisterId, CanisterIdRecord, CanisterInstallMode, CanisterSettings, CreateCanisterArgument,
-    InstallCodeArgument,
-};
 use serde::de::DeserializeOwned;
 use serde::{Deserialize, Serialize};
 use serde_bytes::ByteBuf;
@@ -13,6 +12,10 @@ use std::fmt;
 use std::io::{Read, Write};
 use std::process::{Child, ChildStdin, ChildStdout, Command, Stdio};
 use std::time::{Duration, SystemTime};
+
+mod management_canister;
+
+pub use management_canister::CanisterSettings;
 
 #[derive(Serialize, Deserialize)]
 pub enum Request {

--- a/src/management_canister.rs
+++ b/src/management_canister.rs
@@ -1,0 +1,74 @@
+// `ic-cdk` use this crate as a dependency in its tests.
+// To break the circular dependency, we define the management canister types directly
+// instead of using them from `ic-cdk`.
+// There is a plan to move management canister types out of `ic-cdk`.
+// Once that happens, we can use the management canister types in a consistent way.
+
+use candid::{CandidType, Nat, Principal};
+use serde::{Deserialize, Serialize};
+
+pub(crate) type CanisterId = Principal;
+
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
+)]
+pub struct CanisterSettings {
+    /// A list of principals. Must be between 0 and 10 in size.
+    pub controllers: Option<Vec<Principal>>,
+    /// Must be a number between 0 and 100, inclusively.
+    pub compute_allocation: Option<Nat>,
+    /// Must be a number between 0 and 2^48^ (i.e 256TB), inclusively.
+    pub memory_allocation: Option<Nat>,
+    /// Must be a number between 0 and 2^64^-1, inclusively, and indicates a length of time in seconds.
+    pub freezing_threshold: Option<Nat>,
+}
+
+/// Argument type of [create_canister](super::create_canister).
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Default,
+)]
+pub(crate) struct CreateCanisterArgument {
+    /// See [CanisterSettings].
+    pub settings: Option<CanisterSettings>,
+}
+
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
+)]
+// #[serde(rename_all = "lowercase")]
+pub(crate) enum CanisterInstallMode {
+    /// A fresh install of a new canister.
+    #[serde(rename = "install")]
+    Install,
+    /// Reinstalling a canister that was already installed.
+    #[serde(rename = "reinstall")]
+    Reinstall,
+    /// Upgrade an existing canister.
+    #[serde(rename = "upgrade")]
+    Upgrade,
+}
+
+pub(crate) type WasmModule = Vec<u8>;
+
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone,
+)]
+pub(crate) struct InstallCodeArgument {
+    /// See [CanisterInstallMode].
+    pub mode: CanisterInstallMode,
+    /// Principle of the canister.
+    pub canister_id: CanisterId,
+    /// Code to be installed.
+    pub wasm_module: WasmModule,
+    /// The argument to be passed to `canister_init` or `canister_post_upgrade`.
+    pub arg: Vec<u8>,
+}
+
+/// A wrapper of canister id.
+#[derive(
+    CandidType, Serialize, Deserialize, Debug, PartialEq, Eq, PartialOrd, Ord, Hash, Clone, Copy,
+)]
+pub(crate) struct CanisterIdRecord {
+    /// Principle of the canister.
+    pub canister_id: CanisterId,
+}


### PR DESCRIPTION
Since candid types/traits are in the public API, the version of this crate is also bumped.

This work is necessary for sdk team to upgrade candid in `ic-cdk`.