### PR TITLE
Update CI rust version

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,28 +4,11 @@ on: [pull_request]
 jobs:
   build:
     runs-on: ubuntu-latest
-    strategy:
-      matrix:
-        rust: [ 1.74.0 ]
-
     steps:
       - uses: actions/checkout@v2
 
-      - name: Cache Cargo
-        uses: actions/cache@v2
-        with:
-          path: |
-            ~/.cargo/registry
-            ~/.cargo/git
-            target
-          key: ${{ matrix.build }}-cargo-${{ hashFiles('**/Cargo.lock') }}
-          restore-keys: |
-            ${{ matrix.build }}-cargo-
-
       - name: Install Rust
         run: |
-          rustup update ${{ matrix.rust }} --no-self-update
-          rustup default ${{ matrix.rust }}
           rustup component add rustfmt
           rustup component add clippy
 

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -6,7 +6,7 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        rust: [ 1.65.0 ]
+        rust: [ 1.74.0 ]
 
     steps:
       - uses: actions/checkout@v2


### PR DESCRIPTION
Some dependencies can no longer be built using old rust. Therfore this PR updates the CI rust version.