### PR TITLE
Upgrade candid to v0.10

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,12 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+## [3.0.1] - 2022-11-23
+
+### Chore
+
+- Upgrade `candid` dependency to `0.10`.
+
 ## [3.0.0] - 2022-07-24
 
 ### Added

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "ic-test-state-machine-client"
-version = "3.0.0"
+version = "3.0.1"
 edition = "2021"
 authors = ["The Internet Computer Project Developers"]
 description = "Rust library to interact with the ic-test-state-machine."
@@ -14,7 +14,7 @@ repository = "https://github.com/dfinity/test-state-machine-client"
 
 
 [dependencies]
-candid = "0.9"
+candid = "0.10"
 ciborium = "0.2"
 serde = "1"
 serde_bytes = "0.11"


### PR DESCRIPTION
This upgrades candid to the new libary version which has been split into smaller pieces, hence reducing the size of the dependencies for downstream projects.