### PR TITLE
chore(devops): Add OISY team to CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
-# The codebase is owned by the Governance & Identity Experience team at DFINITY
-# For questions, reach out to: <gix@dfinity.org>
-@dfinity/gix
+# The codebase is owned by the OISY team at DFINITY
+# For questions, reach out to: <oisy-wallet@dfinity.org>
+@dfinity/gix @dfinity/oisy


### PR DESCRIPTION
# Motivation

We are migrating the GitHub [GIX](https://github.com/orgs/dfinity/teams/gix) team to the [OISY](https://github.com/orgs/dfinity/teams/oisy) team. So, first, we need to add the new team as codeowner.