### PR TITLE
chore: Remove GIX team from CODEOWNERS

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -1,3 +1,3 @@
 # The codebase is owned by the OISY team at DFINITY
 # For questions, reach out to: <oisy-wallet@dfinity.org>
-@dfinity/gix @dfinity/oisy
+@dfinity/oisy


### PR DESCRIPTION
# Motivation

We are migrating the GitHub [GIX](https://github.com/orgs/dfinity/teams/gix) team to the [OISY](https://github.com/orgs/dfinity/teams/oisy) team. In this PR we remove the old team as codeowner.